### PR TITLE
setting.ymlの:encoding:に"UTF-8"を設定できるように変更しました。

### DIFF
--- a/lib/reudy/bot_irc_client.rb
+++ b/lib/reudy/bot_irc_client.rb
@@ -47,7 +47,7 @@ module Gimite
           receiveThread = Thread.new{ receiveProcess }
           #受信ループ。
           while line = sock.gets
-            on_recv(line)
+            on_recv(line.force_encoding(@user.settings[:encoding] || "ISO-2022-JP"))
             time = Time.now
             if time - @prevTime >= SILENT_SECOND
               @prevTime = time


### PR DESCRIPTION
setting.ymlの:encoding:に"UTF-8"を設定すると、
"incompatible character encodings: ASCII-8BIT and UTF-8"
が出てロイディが落ちてしまってました。
